### PR TITLE
Add response headers to the upstream error message

### DIFF
--- a/internal/restclient/restclient.go
+++ b/internal/restclient/restclient.go
@@ -91,8 +91,8 @@ func (c *Client) Request(ctx context.Context, method string, url string, in inte
 		return c.Request(ctx, conflictRetryMethod, url, in, out)
 	} else if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return fmt.Errorf(
-			"restclient: request failed: %s %s: %s: %s",
-			req.Method, req.URL, res.Status, resBody,
+			"restclient: request failed: %s %s: %s: %v: %s",
+			req.Method, req.URL, res.Status, res.Header, resBody,
 		)
 	}
 	log.Printf("[TRACE] Received response data %q", string(resBody))


### PR DESCRIPTION
The response headers contain their trace IDs, which should help them help us debug upstream issues more effectively.